### PR TITLE
Added NBA support

### DIFF
--- a/yahoofantasy/api/games.py
+++ b/yahoofantasy/api/games.py
@@ -45,11 +45,32 @@ games['nfl']['2018'] = 380
 games['nfl']['2019'] = 390
 games['nfl']['2020'] = 399
 
+games['nba']['2001'] = 16
+games['nba']['2002'] = 67
+games['nba']['2003'] = 95
+games['nba']['2004'] = 112
+games['nba']['2005'] = 131
+games['nba']['2006'] = 165
+games['nba']['2007'] = 187
+games['nba']['2008'] = 211
+games['nba']['2009'] = 234
+games['nba']['2010'] = 249
+games['nba']['2011'] = 265
+games['nba']['2012'] = 304
+games['nba']['2013'] = 322
+games['nba']['2014'] = 342
+games['nba']['2015'] = 353
+games['nba']['2016'] = 364
+games['nba']['2017'] = 375
+games['nba']['2018'] = 385
+games['nba']['2019'] = 395
+games['nba']['2020'] = 402
+
 
 def get_game_id(game, season):
     season = str(season)
     if game not in games:
-        raise ValueError("{} is not a valid game, must be 'mlb' or 'nfl'".format(game))
+        raise ValueError("{} is not a valid game, must be 'mlb', 'nba' or 'nfl'".format(game))
     if season not in games[game]:
         raise ValueError(
             "{} is not a valid season for {}".format(season, game))

--- a/yahoofantasy/resources/team.py
+++ b/yahoofantasy/resources/team.py
@@ -38,7 +38,7 @@ class Team():
         """
         # First item is the peristence key, second is the API filter
         keys = ('live', '')
-        if week_num > 0:
+        if week_num is not None and week_num > 0:
             keys = (str(week_num), f"week={week_num}")
         data = self.ctx._load_or_fetch(
             f"team.{self.id}.roster.{keys[0]}",


### PR DESCRIPTION
Python is a bit rusty so forgive me if anything looks funny 🙃

Changes: 
1. Updated `games.py` to include all the NBA game codes for 2001-2020 (like MLB and NFL)
2. Updated the error message to include `nba` as a valid game.
3. Added a `None` check in `Team.roster` method that was throwing an error when I was testing it with my league.

Closes #6 