### PR TITLE
Add shell command for yahoofantasy CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ Simplified output example:
 |-|-|-|-|-|-|-|-|
 | drop | drop | Damien Harris | Elementary Mr Watson | waivers | 09/09/2020, 20:57:15 | 36 |  |
 | add/drop | add | James Robinson | waivers | Kittles taste the ðŸŒˆ | 09/11/2020, 00:22:20 | 36 |  |
+
+### Shell (Python interpreter)
+
+A command is available to drop you into a Python interpreter with access to your `Context` object as the `ctx` variable. From the directory where you ran `yahoofantasy login` you can run:
+
+```bash
+yahoofantasy shell
+```
+
 ## Development
 
 Issues, pull requests, and contributions are more than welcome.

--- a/yahoofantasy/cli/__init__.py
+++ b/yahoofantasy/cli/__init__.py
@@ -1,6 +1,7 @@
 import click
 from .login import login
 from .dump import dump
+from .shell import shell
 
 
 @click.group()
@@ -10,3 +11,4 @@ def yahoofantasy():
 
 yahoofantasy.add_command(login)
 yahoofantasy.add_command(dump)
+yahoofantasy.add_command(shell)

--- a/yahoofantasy/cli/shell.py
+++ b/yahoofantasy/cli/shell.py
@@ -1,0 +1,22 @@
+import click
+import code
+from yahoofantasy import Context
+import sys
+from .utils import error
+
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+
+@click.command()
+def shell():
+    try:
+        ctx = Context()  # noqa
+    except Exception:
+        error(
+            "Could not find any yahoofantasy login details, be sure to run `yahoofantasy login` from this directory first"
+        )
+        sys.exit(1)
+
+    code.interact("yahoofantasy Context object available as `ctx`", local=locals())


### PR DESCRIPTION
Adds a new command `yahoofantasy shell` that can be run from a directory with a `.yahoofantasy` persistence directory. This will drop you into a Python interpreter that has access to the yahoofantasy context object
