### PR TITLE
Add cli command to clear cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ A command is available to drop you into a Python interpreter with access to your
 yahoofantasy shell
 ```
 
+### Clearing cache
+
+The yahoofantasy library maintains its own persisted cache of certain Yahoo! API responses. This cuts down on the number of requests that need to be made and makes future function calls faster. Occasionally you may want to clear this cache but not lose your authentication data. You can do so by running the following CLI command from your yahoofantasy project directory:
+
+```bash
+yahoofantasy clear-cache
+```
+
 ## Development
 
 Issues, pull requests, and contributions are more than welcome.

--- a/yahoofantasy/cli/__init__.py
+++ b/yahoofantasy/cli/__init__.py
@@ -2,6 +2,7 @@ import click
 from .login import login
 from .dump import dump
 from .shell import shell
+from .clear_cache import clear_cache
 
 
 @click.group()
@@ -12,3 +13,4 @@ def yahoofantasy():
 yahoofantasy.add_command(login)
 yahoofantasy.add_command(dump)
 yahoofantasy.add_command(shell)
+yahoofantasy.add_command(clear_cache)

--- a/yahoofantasy/cli/clear_cache.py
+++ b/yahoofantasy/cli/clear_cache.py
@@ -1,0 +1,19 @@
+import click
+from yahoofantasy import Context
+import yahoofantasy.util.persistence as persistence
+import sys
+from .utils import error, success
+
+RETAINED_KEYS = ["auth"]
+
+
+@click.command()
+def clear_cache():
+    try:
+        ctx = Context()
+    except Exception:
+        error("Could not find any cached yahoofantasy data in this directory")
+        sys.exit(1)
+
+    persistence.clear(RETAINED_KEYS, ctx._persist_key)
+    success("Cache cleared")

--- a/yahoofantasy/util/persistence.py
+++ b/yahoofantasy/util/persistence.py
@@ -1,3 +1,4 @@
+from copy import copy
 from pydash import set_, get
 from yahoofantasy.util.logger import logger
 from os.path import isfile
@@ -17,7 +18,7 @@ def get_persistence_filename(persist_key):
 
 
 def save(save_path, save_val, persist_key="", overwrite=False):
-    """ Save a key/value pair to persistence
+    """Save a key/value pair to persistence
 
     Args:
         save_path: A pydash path to where the data should be saved
@@ -66,3 +67,14 @@ def load(load_path, default=_DEFAULT_SINGLETON, ttl=DEFAULT_TTL, persist_key="")
     if out is _DEFAULT_SINGLETON:
         raise ValueError("Path {} not found in persistence".format(load_path))
     return out
+
+
+def clear(ignore_keys=[], persist_key=""):
+    out = copy(CURRENT_PERSISTENCE)
+    for key in CURRENT_PERSISTENCE.keys():
+        if key in ignore_keys or key.replace("__time", "") in ignore_keys:
+            continue
+        del out[key]
+    filename = get_persistence_filename(persist_key)
+    with open(filename, "wb") as fp:
+        pickle.dump(out, fp)


### PR DESCRIPTION
The yahoofantasy library maintains its own persisted cache of certain Yahoo! API responses. This cuts down on the number of requests that need to be made and makes future function calls faster. Occasionally you may want to clear this cache but not lose your authentication data. You can do so by running the following CLI command from your yahoofantasy project directory:

```bash
yahoofantasy clear-cache
```