### PR TITLE
Replace deprecated ssl.wrap_socket with SSLContext.wrap_socket for Py…

### DIFF
--- a/yahoofantasy/cli/login.py
+++ b/yahoofantasy/cli/login.py
@@ -65,12 +65,11 @@ def login(
     server = HTTPServer(("", listen_port), Handler)
     if not redirect_http:
         click.echo("Using localhost SSL certificate (HTTPS)")
-        server.socket = ssl.wrap_socket(
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+        server.socket = context.wrap_socket(
             server.socket,
-            server_side=True,
-            certfile=Path(__file__).parent / "localhost.pem",
-            keyfile=Path(__file__).parent / "localhost-key.pem",
-            ssl_version=ssl.PROTOCOL_TLS,
+            server_side=True
         )
     # This will serve until we get a valid access code, then it will shutdown by itself
     server.serve_forever()


### PR DESCRIPTION
Python 3.12 removes functional support for ssl.wrap_socket, which causes the CLI login flow to fail with:
```
AttributeError: module 'ssl' has no attribute 'wrap_socket'
```
This PR updates the login server code to use the modern SSLContext.wrap_socket API, maintaining compatibility with Python 3.12+ while preserving behavior for earlier versions.

🔧 Changes
	•	Replaced ssl.wrap_socket with an SSLContext instance using ssl.PROTOCOL_TLS_SERVER.
	•	Loads certificate and key as before.
	•	Wraps the server socket with context.wrap_socket(..., server_side=True).