### PR TITLE
Fix RuntimeError when iterating players with certain status filters

### DIFF
--- a/yahoofantasy/resources/league.py
+++ b/yahoofantasy/resources/league.py
@@ -79,6 +79,8 @@ class League:
         players = []
         while "player" in data["fantasy_content"]["league"]["players"]:
             for player in data["fantasy_content"]["league"]["players"]["player"]:
+                if not isinstance(player, dict):
+                    continue
                 p = Player(self)
                 from_response_object(p, player)
                 players.append(p)


### PR DESCRIPTION
## Summary

- Yahoo API returns string entries (e.g. `"player_key"`) mixed into the player list for certain status filters (`A`, `W`), rather than only player dictionaries
- These appear to be field-name artifacts from the XML schema slipping through the `badgerfish` XML-to-JSON converter
- `from_response_object` raises a `RuntimeError` when it encounters a string instead of a dict
- Fix: skip any non-dict entries when iterating the player list in `League.players()`

Fixes #85